### PR TITLE
Reactivation of JWT Middleware

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,8 @@
 import {
+  MiddlewareConsumer,
   // MiddlewareConsumer,
   Module,
+  NestModule,
   // NestModule,
   // RequestMethod,
 } from "@nestjs/common";
@@ -9,10 +11,10 @@ import { HelloModule } from "./hello/hello.module";
 import { PrismaModule } from "./prisma/prisma.module";
 import { PrismaService } from "./prisma/prisma.service";
 import { AuthModule } from "./auth/auth.module";
-// import { JwtAuthMiddleware } from "./auth/jwt/middleware/jwt-auth.middleware";
 import { ConfigModule } from "@nestjs/config";
 import { PrometheusModule } from "@willsoto/nestjs-prometheus";
 import { AuditLogModule } from "./auditLog/auditLog.module";
+import { JwtAuthMiddleware } from "./auth/jwt/middleware/jwt-auth.middleware";
 
 @Module({
   imports: [
@@ -28,15 +30,8 @@ import { AuditLogModule } from "./auditLog/auditLog.module";
   ],
   providers: [PrismaService],
 })
-export class AppModule {}
-// export class AppModule implements NestModule {
-//   configure(consumer: MiddlewareConsumer) {
-//     consumer
-//       .apply(JwtAuthMiddleware)
-//       .exclude(
-//         { path: "auth/register", method: RequestMethod.POST },
-//         { path: "auth/login", method: RequestMethod.POST }
-//       )
-//       .forRoutes("*"); // semua route pakai middleware ini.
-//   }
-// }
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(JwtAuthMiddleware).forRoutes("documents/upload");
+  }
+}

--- a/src/auditLog/auditLog.controller.ts
+++ b/src/auditLog/auditLog.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Post } from "@nestjs/common";
+import { Controller, Get } from "@nestjs/common";
 import { AuditLogService } from "./auditLog.service";
 
 @Controller("audit-log")

--- a/src/auditLog/auditLog.service.ts
+++ b/src/auditLog/auditLog.service.ts
@@ -3,7 +3,7 @@ import { PrismaService } from "../prisma/prisma.service";
 
 @Injectable()
 export class AuditLogService {
-  constructor(private prisma: PrismaService) {}
+  constructor(private readonly prisma: PrismaService) {}
 
   async addAuditLog({
     eventType,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -15,7 +15,7 @@ export class AuthService {
   constructor(
     private readonly prismaService: PrismaService,
     private readonly jwtService: JwtService,
-    private auditLogService: AuditLogService,
+    private readonly auditLogService: AuditLogService,
   ) {}
 
   /**

--- a/src/document/controllers/document.controller.spec.ts
+++ b/src/document/controllers/document.controller.spec.ts
@@ -2,8 +2,23 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { DocumentController } from "./document.controller";
 import { DocumentService } from "../services/document.service";
 import * as request from "supertest";
-import { INestApplication, NotFoundException } from "@nestjs/common";
+import {
+  CanActivate,
+  ExecutionContext,
+  INestApplication,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
 import { MulterModule } from "@nestjs/platform-express";
+
+@Injectable()
+class MockAuthGuard implements CanActivate {
+  canActivate(context: ExecutionContext) {
+    const req = context.switchToHttp().getRequest();
+    req.user = { userId: "test-user" };
+    return true;
+  }
+}
 
 describe("DocumentController", () => {
   let app: INestApplication;
@@ -25,6 +40,7 @@ describe("DocumentController", () => {
     }).compile();
 
     app = moduleRef.createNestApplication();
+    app.useGlobalGuards(new MockAuthGuard());
     await app.init();
 
     controller = moduleRef.get<DocumentController>(DocumentController);
@@ -35,23 +51,34 @@ describe("DocumentController", () => {
   afterAll(async () => await app.close());
 
   describe("/documents/upload (POST)", () => {
+    const jwtToken = "Bearer mocked-jwt-token";
+
     it("should upload a valid PDF file under 8MB", async () => {
-      mockDocService.uploadDocument.mockResolvedValue({ success: true });
+      mockDocService.uploadDocument.mockResolvedValue({
+        privateId: "p",
+        publicId: "q",
+      });
 
       const res = await request(app.getHttpServer())
         .post("/documents/upload")
+        .set("Authorization", jwtToken)
         .attach("file", Buffer.from("%PDF-1.4"), "document.pdf")
-        .field("title", "My Doc")
+        .field("documentName", "My Doc")
         .set("Content-Type", "multipart/form-data");
 
       expect(res.status).toBe(201);
-      expect(docService.uploadDocument).toHaveBeenCalled();
+      expect(docService.uploadDocument).toHaveBeenCalledWith(
+        expect.any(Object),
+        { documentName: "My Doc" },
+        "test-user"
+      );
     });
 
     it("should reject when no file is uploaded", async () => {
       const res = await request(app.getHttpServer())
         .post("/documents/upload")
-        .field("title", "No File");
+        .set("Authorization", jwtToken)
+        .field("documentName", "No File");
 
       expect(res.status).toBe(400);
       expect(res.body.message).toBe("No file uploaded.");
@@ -60,8 +87,9 @@ describe("DocumentController", () => {
     it("should reject non-PDF files", async () => {
       const res = await request(app.getHttpServer())
         .post("/documents/upload")
+        .set("Authorization", jwtToken)
         .attach("file", Buffer.from("not-a-pdf"), "image.jpg")
-        .field("title", "Wrong File");
+        .field("documentName", "Wrong File");
 
       expect(res.status).toBe(400);
       expect(res.body.message).toBe("Invalid file type.");
@@ -72,8 +100,9 @@ describe("DocumentController", () => {
 
       const res = await request(app.getHttpServer())
         .post("/documents/upload")
+        .set("Authorization", jwtToken)
         .attach("file", bigBuffer, "big.pdf")
-        .field("title", "Too Big");
+        .field("documentName", "Too Big");
 
       expect(res.status).toBe(400);
       expect(res.body.message).toBe("File size exceeds 8MB limit.");

--- a/src/document/controllers/document.controller.ts
+++ b/src/document/controllers/document.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   ParseUUIDPipe,
   Post,
+  Req,
   UploadedFile,
   UseInterceptors,
 } from "@nestjs/common";
@@ -20,6 +21,7 @@ import {
   ApiOperation,
   ApiResponse,
 } from "@nestjs/swagger";
+import { Request } from "supertest";
 
 @Controller("documents")
 export class DocumentController {
@@ -72,7 +74,8 @@ export class DocumentController {
   @ApiResponse({ status: 500, description: "Internal Server Error" })
   async uploadDocument(
     @UploadedFile() file: Express.Multer.File,
-    @Body() body: UploadDocumentDTO
+    @Req() request: Request,
+    @Body() body: UploadDocumentDTO,
   ) {
     if (!file) {
       throw new BadRequestException("No file uploaded.");
@@ -84,7 +87,11 @@ export class DocumentController {
       throw new BadRequestException("File size exceeds 8MB limit.");
     }
 
-    return await this.docService.uploadDocument(file, body);
+    return await this.docService.uploadDocument(
+      file,
+      body,
+      request["user"].userId,
+    );
   }
 
   @Post("transfer")

--- a/src/document/dto/upload-document.dto.ts
+++ b/src/document/dto/upload-document.dto.ts
@@ -1,13 +1,8 @@
-import { IsEmail, IsNotEmpty } from "class-validator";
+import { IsNotEmpty } from "class-validator";
 import { ApiProperty } from "@nestjs/swagger";
 
 export class UploadDocumentDTO {
   @ApiProperty()
   @IsNotEmpty()
   documentName: string;
-
-  @ApiProperty()
-  @IsEmail()
-  @IsNotEmpty()
-  ownerName: string;
 }

--- a/src/document/repositories/document.repository.ts
+++ b/src/document/repositories/document.repository.ts
@@ -4,7 +4,7 @@ import { PrismaService } from "../../prisma/prisma.service";
 
 @Injectable()
 export class DocumentRepository {
-  constructor(private prisma: PrismaService) {}
+  constructor(private readonly prisma: PrismaService) {}
 
   async createDocument(data: Prisma.DocumentCreateInput) {
     return this.prisma.$transaction(async (transaction) => {

--- a/src/document/services/document.service.spec.ts
+++ b/src/document/services/document.service.spec.ts
@@ -31,6 +31,7 @@ describe("DocumentService", () => {
       $transaction: jest.fn().mockImplementation((fn) => fn(prisma)),
       user: {
         findUnique: jest.fn(),
+        findUniqueOrThrow: jest.fn(),
       },
       qrCode: {
         findUnique: jest.fn(),
@@ -61,18 +62,23 @@ describe("DocumentService", () => {
         documentId: "new-document-id",
       });
 
+      (prisma.user.findUniqueOrThrow as jest.Mock).mockResolvedValue({
+        id: "user-id-123",
+        email: "alice@example.com",
+      });
+
       const file = {
         buffer: Buffer.from("pdf"),
         mimetype: "application/pdf",
       } as any;
-      const dto = { documentName: "My Doc", ownerName: "Alice" };
+      const dto = { documentName: "My Doc" };
 
-      const result = await service.uploadDocument(file, dto);
+      const result = await service.uploadDocument(file, dto, "user-id-123");
       expect(s3Storage.uploadPDF).toHaveBeenCalledWith(
         file.buffer,
         file.mimetype,
         "bucket-name",
-        expect.stringMatching(/^Alice_My-Doc_\d+\.pdf$/),
+        expect.stringMatching(/^alice@example\.com_My-Doc_\d+\.pdf$/),
       );
       expect(repo.createDocument).toHaveBeenCalled();
       expect(result).toEqual({
@@ -84,10 +90,13 @@ describe("DocumentService", () => {
     it("throws if bucket is not configured", async () => {
       config.get.mockReturnValue(undefined);
       await expect(
-        service.uploadDocument({} as any, {
-          documentName: "x",
-          ownerName: "y",
-        }),
+        service.uploadDocument(
+          {} as any,
+          {
+            documentName: "x",
+          },
+          "user-id-123",
+        ),
       ).rejects.toThrow("DO_SPACES_BUCKET is not configured");
     });
 
@@ -99,17 +108,18 @@ describe("DocumentService", () => {
         publicId: "new-qr-public",
         documentId: "new-document-id",
       });
-      (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      (prisma.user.findUniqueOrThrow as jest.Mock).mockResolvedValue({
         id: "user-id-123",
+        email: "alice@example.com",
       });
 
       const file = {
         buffer: Buffer.from("pdf"),
         mimetype: "application/pdf",
       } as any;
-      const dto = { documentName: "Audit Doc", ownerName: "alice@example.com" };
+      const dto = { documentName: "Audit Doc" };
 
-      await service.uploadDocument(file, dto);
+      await service.uploadDocument(file, dto, "user-id-123");
 
       expect(auditLog.addAuditLog).toHaveBeenCalledWith({
         eventType: "UPLOAD_DOCUMENT",
@@ -127,16 +137,16 @@ describe("DocumentService", () => {
         publicId: "new-qr-public",
         documentId: "new-document-id",
       });
-      (prisma.user.findUnique as jest.Mock).mockResolvedValue(null); // simulate user not found
+      (prisma.user.findUniqueOrThrow as jest.Mock).mockRejectedValue(new Error("Not Found"));
 
       const file = {
         buffer: Buffer.from("pdf"),
         mimetype: "application/pdf",
       } as any;
-      const dto = { documentName: "No Audit", ownerName: "ghost@example.com" };
-
-      await service.uploadDocument(file, dto);
-
+      const dto = { documentName: "No Audit" };
+      await expect(
+        service.uploadDocument(file, dto, "ghost-user"),
+      ).rejects.toThrow();
       expect(auditLog.addAuditLog).not.toHaveBeenCalled();
     });
   });
@@ -333,8 +343,8 @@ describe("DocumentService", () => {
     });
 
     it("generateFilename sanitizes names and formats correctly", () => {
-      const dto = { ownerName: "John Doe", documentName: "My Doc" };
-      const result = (service as any).generateFilename(dto, 123456);
+      const dto = { documentName: "My Doc" };
+      const result = (service as any).generateFilename(dto, 123456, "John Doe");
       expect(result).toBe("John-Doe_My-Doc_123456.pdf");
     });
   });

--- a/src/document/services/document.service.ts
+++ b/src/document/services/document.service.ts
@@ -25,13 +25,22 @@ export class DocumentService {
     private readonly auditLogService: AuditLogService,
   ) {}
 
-  async uploadDocument(pdf: Express.Multer.File, dto: UploadDocumentDTO) {
+  async uploadDocument(
+    pdf: Express.Multer.File,
+    dto: UploadDocumentDTO,
+    userId: string,
+  ) {
+    const user = await this.prisma.user.findUniqueOrThrow({
+      where: {
+        id: userId,
+      },
+    });
     const bucketName = this.getBucketName();
-    const filename = this.generateFilename(dto, Date.now());
+    const filename = this.generateFilename(dto, Date.now(), user.email);
 
-    await this.posthogService.captureEvent(dto.ownerName, "document_upload", {
+    await this.posthogService.captureEvent(user.email, "document_upload", {
       filename,
-      ownerName: dto.ownerName,
+      ownerName: user.email,
       timestamp: Date.now(),
     });
 
@@ -39,28 +48,22 @@ export class DocumentService {
       pdf.buffer,
       pdf.mimetype,
       bucketName,
-      filename
+      filename,
     );
 
     const createdDocument = await this.documentRepo.createDocument({
       documentName: dto.documentName,
       filePath: url,
       uploadDate: new Date(),
-      publisher: dto.ownerName,
+      publisher: user.email,
     });
 
-    const user = await this.prisma.user.findUnique({
-      where: { email: dto.ownerName },
+    await this.auditLogService.addAuditLog({
+      eventType: "UPLOAD_DOCUMENT",
+      userID: user.id,
+      details: `Document "${dto.documentName}" uploaded.`,
+      documentID: createdDocument.documentId,
     });
-
-    if (user) {
-      await this.auditLogService.addAuditLog({
-        eventType: "UPLOAD_DOCUMENT",
-        userID: user.id,
-        details: `Document "${dto.documentName}" uploaded.`,
-        documentID: createdDocument.documentId,
-      });
-    }
 
     return {
       privateId: createdDocument.privateId,
@@ -100,7 +103,7 @@ export class DocumentService {
       document.documentName,
       this.getCurrentOwner(document),
       document.publisher,
-      documentId
+      documentId,
     );
 
     return { otp: otp };
@@ -161,9 +164,13 @@ export class DocumentService {
     return bucketName;
   }
 
-  private generateFilename(dto: UploadDocumentDTO, timestamp: number): string {
+  private generateFilename(
+    dto: UploadDocumentDTO,
+    timestamp: number,
+    owner: string,
+  ): string {
     const sanitize = (str: string) => str.replace(/\s+/g, "-");
-    return `${sanitize(dto.ownerName)}_${sanitize(dto.documentName)}_${timestamp}.pdf`;
+    return `${sanitize(owner)}_${sanitize(dto.documentName)}_${timestamp}.pdf`;
   }
 
   private getCurrentOwner(document) {

--- a/src/document/services/email.service.ts
+++ b/src/document/services/email.service.ts
@@ -5,11 +5,11 @@ import { DocumentRepository } from "../repositories/document.repository";
 
 @Injectable()
 export class EmailService {
-  private transporter: nodemailer.Transporter;
+  private readonly transporter: nodemailer.Transporter;
 
   constructor(
-    private configService: ConfigService,
-    private documentRepo: DocumentRepository,
+    private readonly configService: ConfigService,
+    private readonly documentRepo: DocumentRepository,
   ) {
     this.transporter = nodemailer.createTransport({
       service: "gmail",

--- a/src/posthog/posthog.service.spec.ts
+++ b/src/posthog/posthog.service.spec.ts
@@ -1,5 +1,7 @@
 import axios from "axios";
 import { PostHogService } from "./posthog.service";
+import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigService } from "@nestjs/config";
 
 jest.mock("axios");
 const mockedAxios = axios as jest.Mocked<typeof axios>;
@@ -7,11 +9,26 @@ const mockedAxios = axios as jest.Mocked<typeof axios>;
 describe("PostHogService", () => {
   let service: PostHogService;
   const apiUrl = "https://app.posthog.com/capture";
-  const apiKey = "phc_y5HJD0i3FYXaowP2gRA8RlRSWS7f6THPk6pG8oIV39J";
+  const apiKey = "skibiditoilet";
 
-  beforeEach(() => {
-    service = new PostHogService();
+  beforeEach(async () => {
     jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PostHogService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn().mockImplementation((key: string) => {
+              if (key === "POSTHOG_APIKEY") {
+                return apiKey;
+              }
+            }),
+          },
+        },
+      ],
+    }).compile();
+    service = module.get<PostHogService>(PostHogService);
   });
 
   it("should call axios.post with correct parameters", async () => {

--- a/src/posthog/posthog.service.ts
+++ b/src/posthog/posthog.service.ts
@@ -1,19 +1,21 @@
 import { Injectable } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
 import axios from "axios";
 
 @Injectable()
 export class PostHogService {
-  private readonly apiKey = "phc_y5HJD0i3FYXaowP2gRA8RlRSWS7f6THPk6pG8oIV39J";
   private readonly apiUrl = "https://app.posthog.com/capture";
+
+  constructor(private readonly configService: ConfigService) {}
 
   async captureEvent(
     distinctId: string,
     event: string,
-    properties?: Record<string, any>
+    properties?: Record<string, any>,
   ) {
     try {
       await axios.post(this.apiUrl, {
-        api_key: this.apiKey,
+        api_key: this.configService.get<string>("POSTHOG_APIKEY"),
         event,
         properties,
         distinct_id: distinctId,


### PR DESCRIPTION
What's new:
1. Autentikasi dengan JWT sudah dinyalakan lagi
2. Route yang dilindungi hanya /documents/upload, sisanya seperti register, login, scan QR code, dll bisa dibuka tanpa harus login
3. Route /documents/upload sekarang mengambil field ownerName dari JWT tokennya, bukan lagi dari body post request.