### PR TITLE
Create Admin Role and Admin Guard Middleware

### DIFF
--- a/prisma/migrations/20250424025705_add_enum_role/migration.sql
+++ b/prisma/migrations/20250424025705_add_enum_role/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - The `role` column on the `users` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('USER', 'ADMIN');
+
+-- AlterTable
+ALTER TABLE "users" DROP COLUMN "role",
+ADD COLUMN     "role" "Role" NOT NULL DEFAULT 'USER';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,6 +14,11 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum Role {
+    USER
+    ADMIN
+}
+
 model Message {
   id        Int      @id @default(autoincrement())
   content   String
@@ -26,7 +31,7 @@ model User {
   id         String @id @default(uuid())
   email      String @unique
   password   String
-  role       String
+  role       Role @default(USER)
   lastLogout BigInt
 
   @@map("users")

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,11 +1,10 @@
 import {
   MiddlewareConsumer,
-  // MiddlewareConsumer,
   Module,
   NestModule,
-  // NestModule,
-  // RequestMethod,
+  RequestMethod,
 } from "@nestjs/common";
+import { APP_GUARD } from "@nestjs/core";
 import { DocumentsModule } from "./document/document.module";
 import { HelloModule } from "./hello/hello.module";
 import { PrismaModule } from "./prisma/prisma.module";
@@ -15,6 +14,8 @@ import { ConfigModule } from "@nestjs/config";
 import { PrometheusModule } from "@willsoto/nestjs-prometheus";
 import { AuditLogModule } from "./auditLog/auditLog.module";
 import { JwtAuthMiddleware } from "./auth/jwt/middleware/jwt-auth.middleware";
+import { RolesGuard } from "./auth/roles.guard";
+import { AdminSeederService } from "./auth/adminseeder.service";
 
 @Module({
   imports: [
@@ -28,10 +29,19 @@ import { JwtAuthMiddleware } from "./auth/jwt/middleware/jwt-auth.middleware";
     }),
     AuditLogModule,
   ],
-  providers: [PrismaService],
+  providers: [
+    PrismaService,
+    { provide: APP_GUARD, useClass: RolesGuard },
+    AdminSeederService,
+  ],
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
-    consumer.apply(JwtAuthMiddleware).forRoutes("documents/upload");
+    consumer
+      .apply(JwtAuthMiddleware)
+      .forRoutes(
+        { path: "documents/upload", method: RequestMethod.ALL },
+        { path: "audit-log", method: RequestMethod.ALL },
+      );
   }
 }

--- a/src/auditLog/auditLog.controller.spec.ts
+++ b/src/auditLog/auditLog.controller.spec.ts
@@ -1,6 +1,11 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { AuditLogService } from "./auditLog.service";
 import { AuditLogController } from "./auditLog.controller";
+import { JwtAuthMiddleware } from "../auth/jwt/middleware/jwt-auth.middleware";
+import { RolesGuard } from "../auth/roles.guard";
+import { JwtService } from "../auth/jwt/jwt.service";
+import { PrismaService } from "../prisma/prisma.service";
+import { ConfigService } from "@nestjs/config";
 
 describe("AuditLogController", () => {
   let controller: AuditLogController;
@@ -22,13 +27,27 @@ describe("AuditLogController", () => {
           provide: AuditLogService,
           useValue: mockAuditLogService,
         },
+        {
+          provide: JwtAuthMiddleware,
+          useValue: { use: (_req, _res, next) => next() },
+        },
+        {
+          provide: RolesGuard,
+          useValue: { canActivate: () => true },
+        },
+        {
+          provide: JwtService,
+          useValue: {},
+        },
+        {
+          provide: PrismaService,
+          useValue: {},
+        },
       ],
     }).compile();
 
     controller = module.get<AuditLogController>(AuditLogController);
   });
-
-
 
   describe("getAllAuditLogs", () => {
     it("should return all audit logs (positive test)", async () => {

--- a/src/auditLog/auditLog.controller.ts
+++ b/src/auditLog/auditLog.controller.ts
@@ -1,11 +1,16 @@
-import { Controller, Get } from "@nestjs/common";
+import { Controller, Get, UseGuards } from "@nestjs/common";
+import { JwtAuthMiddleware } from "../auth/jwt/middleware/jwt-auth.middleware";
+import { Roles } from "../auth/roles.decorator";
+import { RolesGuard } from "../auth/roles.guard";
 import { AuditLogService } from "./auditLog.service";
 
 @Controller("audit-log")
+@UseGuards(JwtAuthMiddleware, RolesGuard)
 export class AuditLogController {
   constructor(private readonly auditLogService: AuditLogService) {}
 
   @Get()
+  @Roles("ADMIN")
   async getAllAuditLogs() {
     return this.auditLogService.getAllAuditLogs();
   }

--- a/src/auditLog/auditLog.module.ts
+++ b/src/auditLog/auditLog.module.ts
@@ -1,10 +1,11 @@
 import { Module } from "@nestjs/common";
 import { AuditLogController } from "./auditLog.controller";
 import { AuditLogService } from "./auditLog.service";
+import { JwtService } from "../auth/jwt/jwt.service";
 
 @Module({
   controllers: [AuditLogController],
-  providers: [AuditLogService],
+  providers: [AuditLogService, JwtService],
   exports: [AuditLogService],
 })
 export class AuditLogModule {}

--- a/src/auth/adminseeder.service.spec.ts
+++ b/src/auth/adminseeder.service.spec.ts
@@ -1,0 +1,55 @@
+import { AdminSeederService } from "./adminseeder.service";
+import { ConfigService } from "@nestjs/config";
+import * as argon2 from "argon2";
+
+describe("AdminSeederService", () => {
+  let service: AdminSeederService;
+  let config: Partial<ConfigService>;
+  let prisma: any;
+  const adminEmail = "admin@test.com";
+  const adminPass = "Secret123!";
+
+  beforeEach(() => {
+    config = { get: jest.fn() } as any;
+    prisma = {
+      user: {
+        findUnique: jest.fn(),
+        create: jest.fn(),
+      },
+    };
+    service = new AdminSeederService(prisma, config as ConfigService);
+  });
+
+  it("skips seeding if env vars missing", async () => {
+    (config.get as jest.Mock).mockReturnValueOnce(undefined).mockReturnValueOnce(undefined);
+    console.warn = jest.fn();
+    await service.onModuleInit();
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+    expect(prisma.user.create).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it("does not create if admin already exists", async () => {
+    (config.get as jest.Mock).mockReturnValueOnce(adminEmail).mockReturnValueOnce(adminPass);
+    prisma.user.findUnique.mockResolvedValue({ id: "1", role: "ADMIN" });
+    await service.onModuleInit();
+    expect(prisma.user.findUnique).toHaveBeenCalledWith({ where: { email: adminEmail } });
+    expect(prisma.user.create).not.toHaveBeenCalled();
+  });
+
+  it("creates admin if not exists", async () => {
+    (config.get as jest.Mock).mockReturnValueOnce(adminEmail).mockReturnValueOnce(adminPass);
+    prisma.user.findUnique.mockResolvedValue(null);
+    jest.spyOn(argon2, "hash").mockResolvedValue("hashedpass");
+    await service.onModuleInit();
+    expect(argon2.hash).toHaveBeenCalledWith(adminPass);
+    expect(prisma.user.create).toHaveBeenCalledWith({
+      data: {
+        email: adminEmail,
+        password: "hashedpass",
+        role: "ADMIN",
+        lastLogout: expect.any(BigInt),
+      },
+    });
+  });
+});

--- a/src/auth/adminseeder.service.ts
+++ b/src/auth/adminseeder.service.ts
@@ -1,0 +1,37 @@
+import { Injectable, OnModuleInit } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { PrismaService } from "../prisma/prisma.service";
+import * as argon2 from "argon2";
+
+@Injectable()
+export class AdminSeederService implements OnModuleInit {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly config: ConfigService,
+  ) {}
+
+  async onModuleInit() {
+    const email = this.config.get<string>("ADMIN_EMAIL");
+    const password = this.config.get<string>("ADMIN_PASSWORD");
+    if (!email || !password) {
+      console.warn(
+        "ADMIN_EMAIL or ADMIN_PASSWORD not set, skipping admin seeding",
+      );
+      return;
+    }
+
+    const existing = await this.prisma.user.findUnique({ where: { email } });
+    if (!existing) {
+      const hash = await argon2.hash(password);
+      await this.prisma.user.create({
+        data: {
+          email,
+          password: hash,
+          role: "ADMIN",
+          lastLogout: BigInt(Date.now()),
+        },
+      });
+      console.log(`✅ Created initial admin user: ${email}`);
+    }
+  }
+}

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -4,6 +4,7 @@ import { AuthService } from "./auth.service";
 import { AuthDto } from "./dto";
 import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
 import { ForbiddenException } from "@nestjs/common";
+import { Role } from "@prisma/client";
 
 describe("AuthController", () => {
   let authController: AuthController;
@@ -50,7 +51,7 @@ describe("AuthController", () => {
     const mockResponse = {
       id: "123",
       email: dto.email,
-      role: "user",
+      role: Role.USER,
     };
 
     jest.spyOn(authService, "register").mockResolvedValue(mockResponse);
@@ -97,7 +98,7 @@ describe("AuthController", () => {
       user: {
         id: "123",
         email: dto.email,
-        role: "user",
+        role: Role.USER,
       },
     };
 

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -7,6 +7,7 @@ import { BadRequestException, ForbiddenException } from "@nestjs/common";
 import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
 import { JwtService } from "./jwt/jwt.service";
 import { AuditLogService } from "../auditLog/auditLog.service";
+import { Role } from "@prisma/client";
 
 describe("AuthService", () => {
   let authService: AuthService;
@@ -134,7 +135,7 @@ describe("AuthService", () => {
       id: "123",
       email: "test@test.com",
       password: "hashedpassword",
-      role: "user",
+      role: Role.USER,
       lastLogout: BigInt(Date.now()),
     };
 
@@ -148,7 +149,6 @@ describe("AuthService", () => {
       data: {
         email: dto.email,
         password: "hashedpassword",
-        role: "user",
         lastLogout: expect.any(BigInt),
       },
     });
@@ -213,7 +213,7 @@ describe("AuthService", () => {
       id: "123",
       email: dto.email,
       password: "hashedpassword",
-      role: "user",
+      role: Role.USER,
       lastLogout: BigInt(Date.now()),
     };
 
@@ -264,7 +264,7 @@ describe("AuthService", () => {
       id: "123",
       email: dto.email,
       password: "hashedpassword",
-      role: "user",
+      role: Role.USER,
       lastLogout: BigInt(Date.now()),
     };
 
@@ -305,7 +305,7 @@ describe("AuthService", () => {
       id: string;
       email: string;
       password: string;
-      role: string;
+      role: Role;
       lastLogout: bigint;
     };
 
@@ -314,7 +314,7 @@ describe("AuthService", () => {
         id: "123",
         email: "test@test.com",
         password: "hashedpassword",
-        role: "user",
+        role: Role.USER,
         lastLogout: BigInt(0),
       };
     });

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -71,7 +71,6 @@ export class AuthService {
         data: {
           email: dto.email,
           password: hash,
-          role: "user",
           lastLogout: BigInt(Date.now()),
         },
       });

--- a/src/auth/roles.decorator.ts
+++ b/src/auth/roles.decorator.ts
@@ -1,0 +1,3 @@
+import { SetMetadata } from "@nestjs/common";
+export const ROLES_KEY = "roles";
+export const Roles = (...roles: string[]) => SetMetadata(ROLES_KEY, roles);

--- a/src/auth/roles.guard.spec.ts
+++ b/src/auth/roles.guard.spec.ts
@@ -1,0 +1,64 @@
+import { Reflector } from "@nestjs/core";
+import { ForbiddenException, ExecutionContext } from "@nestjs/common";
+import { RolesGuard } from "./roles.guard";
+import { PrismaService } from "../prisma/prisma.service";
+
+describe("RolesGuard", () => {
+  let guard: RolesGuard;
+  let reflector: Reflector;
+  let prisma: any;
+  const mockCtx = (
+    user: any,
+    handlerRoles: string[] | undefined,
+  ): ExecutionContext =>
+    ({
+      getHandler: () => {},
+      switchToHttp: () => ({ getRequest: () => ({ user }) }),
+    } as any);
+
+  beforeEach(() => {
+    reflector = new Reflector();
+    prisma = {
+      user: { findUnique: jest.fn() },
+    };
+    guard = new RolesGuard(reflector, prisma as PrismaService);
+  });
+
+  it("should allow when no roles metadata", async () => {
+    jest.spyOn(reflector, "get").mockReturnValue(undefined);
+    await expect(
+      guard.canActivate(mockCtx({ userId: "1" }, undefined)),
+    ).resolves.toBe(true);
+  });
+
+  it("should allow when user has required role", async () => {
+    jest.spyOn(reflector, "get").mockReturnValue(["ADMIN"]);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: "1",
+      role: "ADMIN",
+    });
+    await expect(
+      guard.canActivate(mockCtx({ userId: "1" }, ["ADMIN"])),
+    ).resolves.toBe(true);
+    expect(prisma.user.findUnique).toHaveBeenCalledWith({ where: { id: "1" } });
+  });
+
+  it("should throw if user not found", async () => {
+    jest.spyOn(reflector, "get").mockReturnValue(["ADMIN"]);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+    await expect(
+      guard.canActivate(mockCtx({ userId: "1" }, ["ADMIN"])),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it("should throw if user lacks required role", async () => {
+    jest.spyOn(reflector, "get").mockReturnValue(["ADMIN"]);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: "1",
+      role: "USER",
+    });
+    await expect(
+      guard.canActivate(mockCtx({ userId: "1" }, ["ADMIN"])),
+    ).rejects.toThrow(ForbiddenException);
+  });
+});

--- a/src/auth/roles.guard.ts
+++ b/src/auth/roles.guard.ts
@@ -1,0 +1,31 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import { PrismaService } from "../prisma/prisma.service";
+import { ROLES_KEY } from "./roles.decorator";
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(
+    private reflector: Reflector,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  async canActivate(ctx: ExecutionContext): Promise<boolean> {
+    const required = this.reflector.get<string[]>(ROLES_KEY, ctx.getHandler());
+    if (!required?.length) return true;
+
+    const req = ctx.switchToHttp().getRequest();
+    const { userId } = req.user as { userId: string };
+
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+    if (!user || !required.includes(user.role)) {
+      throw new ForbiddenException("Insufficient permissions");
+    }
+    return true;
+  }
+}

--- a/src/auth/roles.guard.ts
+++ b/src/auth/roles.guard.ts
@@ -11,7 +11,7 @@ import { ROLES_KEY } from "./roles.decorator";
 @Injectable()
 export class RolesGuard implements CanActivate {
   constructor(
-    private reflector: Reflector,
+    private readonly reflector: Reflector,
     private readonly prisma: PrismaService,
   ) {}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,7 @@ async function bootstrap() {
   app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true,
-    })
+    }),
   );
   app.enableCors();
   app.useGlobalPipes(new ValidationPipe());
@@ -39,7 +39,7 @@ async function bootstrap() {
   SwaggerModule.setup(
     configService.get<string>("API_ENDPOINT", "api-default"),
     app,
-    documentFactory
+    documentFactory,
   );
 
   await app.listen(process.env.PORT ?? 4000);


### PR DESCRIPTION
What's new:
Pull request ini menambahkan role-based access control berupa role admin baru untuk melindungi endpoint /audit-log. Selain itu, terdapat juga seeder untuk akun admin yang akan otomatis membuat akun admin jika belum ada di database.
- Terdapat enum `Role` Baru yang berisi `USER` dan `ADMIN`
- Terdapat `RolesGuard` untuk menerapkan role-based access control
- `AuditLogController` kini sekarang harus diakses sebagai `ADMIN`
- Terdapat `AdminSeederService` yang bertugas untuk membuat akun admin dengan mengambil `ADMIN_EMAIL` dan `ADMIN_PASSWORD` dari environment variable