### PR TITLE
prepend domain in QR code links

### DIFF
--- a/src/document/services/email.service.ts
+++ b/src/document/services/email.service.ts
@@ -71,24 +71,28 @@ export class EmailService {
     publicQrCodeId: string,
     privateQrCodeId: string
   ): Promise<void> {
+    const domain = "https://avento-origin.vercel.app/metadata/";
+    const publicQrURL = `${domain}${publicQrCodeId}`;
+    const privateQrURL = `${domain}${privateQrCodeId}`;
+
     const ownershipGrantedHTML = `
-  <p>
-    Anda telah diberikan kepemilikan atas dokumen <strong>${documentName}</strong> melalui <strong>Avento Origin</strong>.
-  </p>
-  <p>
-    Ini adalah informasi QR Code Anda:
-  </p>
-  <ul>
-    <li>
-      <strong>Public QR Code ID (untuk verifikasi kepemilikan):</strong><br />
-      <a href="${publicQrCodeId}" target="_blank">${publicQrCodeId}</a>
-    </li>
-    <li>
-      <strong>Private QR Code ID (Penggunaan Pribadi untuk transfer & melihat dokumen):</strong><br />
-      <a href="${privateQrCodeId}" target="_blank">${privateQrCodeId}</a>
-    </li>
-  </ul>
-`;
+    <p>
+      Anda telah diberikan kepemilikan atas dokumen <strong>${documentName}</strong> melalui <strong>Avento Origin</strong>.
+    </p>
+    <p>
+      Ini adalah informasi QR Code Anda:
+    </p>
+    <ul>
+      <li>
+        <strong>Public QR Code ID (untuk verifikasi kepemilikan):</strong><br />
+        <a href="${publicQrURL}" target="_blank">${publicQrURL}</a>
+      </li>
+      <li>
+        <strong>Private QR Code ID (Penggunaan Pribadi untuk transfer & melihat dokumen):</strong><br />
+        <a href="${privateQrURL}" target="_blank">${privateQrURL}</a>
+      </li>
+    </ul>
+  `;
 
     const ownershipRevokedHTML = `
 <p>


### PR DESCRIPTION
### Summary:
Refactored the email template generation to use variables for constructing QR code URLs with the domain `https://avento-origin.vercel.app/metadata/`. This change improves maintainability by centralizing the domain definition and reducing repetition.

### Changes:
- Defined `domain` variable to prepend the domain to the QR code IDs.
- Updated public and private QR code URL generation with the new variable.

### Impact:
This change simplifies future updates to the domain and ensures consistency in QR code URL formatting across the codebase.

### Testing:
- Verified that email content is rendered correctly with the full QR code URLs.
- Ensured that the logic still works with dynamic QR code IDs.